### PR TITLE
Small fix for human review not appearing on some pages in complete csv

### DIFF
--- a/deploy_code/multipagepdfa2i_humancomplete/lambda_function.py
+++ b/deploy_code/multipagepdfa2i_humancomplete/lambda_function.py
@@ -59,8 +59,8 @@ def get_token(payload):
     return token
 
 def create_final_dest(id, key):
-    extension = key[-3:].lower()
-    if extension is not "pdf":
+    prefix = key[:3].lower()
+    if prefix != "wip":
         final_dest = "wip/" + id + "/0.png"
     else:
         final_dest = key


### PR DESCRIPTION
fixes a bug where the complete output csv doesn't show the human reviews on pages after the first page.

*Issue #, if available:*

*Description of changes:*
Fixes a substring error when searching for PDF suffix when a PNG is actually being processed. Grabs the prefix instead of suffix to resolve problem

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
